### PR TITLE
App Install Location

### DIFF
--- a/android_app/app/src/main/AndroidManifest.xml
+++ b/android_app/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="me.hda.urlhda" >
+    package="me.hda.urlhda" android:installLocation="auto" >
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

"To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto"." (source: https://developer.android.com/guide/topics/data/install-location.html)

Thank you very much for your awesome app :)
